### PR TITLE
Use xhr.response instead xhr.responseText

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -23,7 +23,7 @@ var interceptor = {
                     url: lastURL,
                     method: lastMethod.toUpperCase(),
                     headers: xhr.getAllResponseHeaders(),
-                    body: xhr.responseText,
+                    body: xhr.response,
                     statusCode: xhr.status
                 };
                 window[NAMESPACE].requests.push(req);


### PR DESCRIPTION
Accessing `xhr.responseText` can cause an error if `responseType` is `Blob`
