### PR TITLE
Don't throw error if no requests are found

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,9 +110,9 @@ function plugin (wdInstance, options) {
     function getRequest (index) {
         return wdInstance.execute(interceptor.getRequest, index)
             .then(function (request) {
-                if (!request.value) {
-                    const message = index ? 'Could not find request with index ' + index : 'No requests captured';
-                    return (index ? Promise.reject(new Error(message)) : []);
+                if (!request.value && index) {
+                    const message = 'Could not find request with index ' + index;
+                    return Promise.reject(new Error(message));
                 }
                 if (Array.isArray(request.value)) {
                     return request.value.map(transformRequest);

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ function plugin (wdInstance, options) {
             .then(function (request) {
                 if (!request.value) {
                     const message = index ? 'Could not find request with index ' + index : 'No requests captured';
-                    return Promise.reject(new Error(message));
+                    return (index ? Promise.reject(new Error(message)) : []);
                 }
                 if (Array.isArray(request.value)) {
                     return request.value.map(transformRequest);


### PR DESCRIPTION
I have been trying to print out a list of any recent requests made when webdriverio encounters an error.  An obvious way to do this involves using the wdio onError hook like such
```
onError: function(message) {
  const requests = browser.getRequests();
  requests.forEach((request) => {
    console.log(JSON.stringify(request, null, 2));
  });
}
```

However if no requests are returned another Error is thrown causing the onError hook to be triggered again... which then calls getRequest, creating an infinite loop.  To me It doesn't seem necessary to throw an error if no requests are found and makes it harder to use this library for debugging purposes.