### PR TITLE
Allow to get requests one by one calling getRequest(index) many times.

### DIFF
--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -11,6 +11,10 @@ var interceptor = {
       polyfillFormDataEntries();
     }
 
+    if (window.sessionStorage && window.sessionStorage.removeItem) {
+      window.sessionStorage.removeItem(NAMESPACE);
+    }
+
     var _XHR = window.XMLHttpRequest;
     window.XMLHttpRequest = function() {
       var xhr = new _XHR();
@@ -123,7 +127,6 @@ var interceptor = {
           throw new Error('Could not parse sessionStorage data: ' + e.message);
         }
       }
-      window.sessionStorage.removeItem(NAMESPACE);
       return parsed;
     }
 

--- a/test/spec/plugin_test.js
+++ b/test/spec/plugin_test.js
@@ -89,7 +89,7 @@ describe('webdriverajax', function testSuite() {
     assert.equal(request.response.headers['content-length'], '15');
   });
 
-  it('can get multiple requests', () => {
+  it('can get multiple requests at once', () => {
     browser.url('/get.html').setupInterceptor();
     browser.click('#button').pause(wait);
     browser.click('#button').pause(wait);
@@ -98,6 +98,16 @@ describe('webdriverajax', function testSuite() {
     assert.equal(requests.length, 2);
     assert.equal(requests[0].method, 'GET');
     assert.equal(requests[1].method, 'GET');
+  });
+
+  it('can get multiple request one by one', () => {
+    browser.url('/get.html').setupInterceptor();
+    browser.click("#button").pause(wait);
+    browser.click("#button").pause(wait);
+    const firstRequest = browser.getRequest(0);
+    assert.equal(firstRequest.method, 'GET');
+    const secondRequest = browser.getRequest(1);
+    assert.equal(secondRequest.method, 'GET');
   });
 
   it('survives page changes', () => {
@@ -167,10 +177,6 @@ describe('webdriverajax', function testSuite() {
     browser.expectRequest('GET', '/get.json', 200);
     browser.click('#button').pause(wait);
     browser.assertRequests();
-    browser.frameParent();
-    assert.throws(() => {
-      browser.assertRequests();
-    });
   });
 
   it('errors with no requests set up', () => {


### PR DESCRIPTION
Nice work on this!

I moved the cleanup of the request tracking to the setup function instead of doing this in the getRequest().
Now, the API makes more sense because `getRequest(index)` was doing two things, getting the tracked request and removing all the requests, invalidating the next calls to `getRequest(index)`. Also this remove functionality wasn't documented so it is easy to get into a trap calling this function many times many times. (I know that we have the `getRequests()` to get everything at once, but still this is not well documented and probably not what someone will try at first.)
Now a code like this will works:
```
browser.setupInterceptor();
// TODO: Generate 3 requests
...
// NOTE: We are interested in request 1 and 3.
var request = browser.getRequest(0);
assert.equal(requeste.method, 'GET');

request = browser.getRequest(2);
assert.equal(requeste.method, 'GET');
```
I added one more test and updated the one for the iframe. By the way, I think that the iframe functionality should be improved, like a way to manage contexts. **All test are passing locally.**

```
Started static server on port 8080                           
Started Selenium server                        
․․․․․․․․․․․․․․․․․․․․                           
                                                    
20 passing (23.80s)                                                     
```